### PR TITLE
Added testing docs for docker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ int main() {
 }
 ```
 
+The example above shown can be run as follows for a quick test on your environment setup
+```
+gcc test.c ./src/docker.c -o test -std=c99 -lcurl -I ./src
+./test
+```
+
+
 ## Adding as CMake subdirectory dependency
 Add the following lines to your ```CMakeLists.txt```.
 ```

--- a/src/docker.c
+++ b/src/docker.c
@@ -107,3 +107,4 @@ CURLcode docker_get(DOCKER *client, char *url) {
   init_curl(client);
   return perform(client, url);
 }
+

--- a/test.c
+++ b/test.c
@@ -1,0 +1,30 @@
+#include "docker.h"
+
+
+
+int main() {
+
+    fprintf(stderr, "curl_version: %s\n", curl_version());
+
+      DOCKER *docker = docker_init("v1.25");
+
+        if (docker) {
+              CURLcode response = docker_post(docker, "http://v1.25/containers/create",
+                                                      "{\"Image\": \"alpine\", \"Cmd\": [\"echo\", \"hello world\"]}");
+                  if (response == CURLE_OK) {
+                          fprintf(stderr, "%s\n", docker_buffer(docker));
+                              }
+
+                      response = docker_get(docker, "http://v1.25/images/json");
+
+                          if (response == CURLE_OK) {
+                                  fprintf(stderr, "%s\n", docker_buffer(docker));
+                                      }
+
+                              docker_destroy(docker);
+                                } else {
+                                      fprintf(stderr, "ERROR: Failed to get get a docker client!\n");
+                                        }
+
+          return 0;
+}


### PR DESCRIPTION
**Description**
Adds docs on a quick test for the API with the code sample in a `test.c` for easy use

**Notes**
Additional documentation on a quick test in a non-cmake environment was also added
```
gcc test.c ./src/docker.c -o test -std=c99 -lcurl -I ./src
./test
```
