### PR TITLE
fixed few memory issues, 0 terminate in version string and init_buffe…

### DIFF
--- a/src/docker.c
+++ b/src/docker.c
@@ -26,7 +26,7 @@ static size_t write_function(void *data, size_t size, size_t nmemb, void *buffer
 }
 
 void init_buffer(DOCKER *client) {
-  client->buffer->data = (char *) malloc(1);
+  client->buffer->data = NULL;
   client->buffer->size = 0;
 }
 
@@ -46,7 +46,7 @@ CURLcode perform(DOCKER *client, char *url) {
 }
 
 DOCKER *docker_init(char *version) {
-  size_t version_len = strlen(version);
+  size_t version_len = strlen(version)+1;
 
   if (version_len < 5) {
     fprintf(stderr, "WARNING: version malformed.");
@@ -56,7 +56,7 @@ DOCKER *docker_init(char *version) {
   DOCKER *client = (DOCKER *) malloc(sizeof(struct docker));
 
   client->buffer = (struct buffer *) malloc(sizeof(struct buffer));
-
+  init_buffer(client);
 
   client->version = (char *) malloc(sizeof(char) * version_len);
   if (client->version == NULL) {


### PR DESCRIPTION
because init_buffer() is not called on create buffer object in docker_init() if docker_destroy(0 is called right after, it will try to free free(client->buffer->data); uninitialized memory. 
Also docker_init() is not properly copying version string, not adding null at the end. 
Also there is no need to allocate 1 byte data in init_buffer, null will do as call o realloc later with NULL is equivalent of malloc